### PR TITLE
Set in stone the port number and improve app message on launch

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,6 +3,8 @@ const Busboy = require("busboy");
 const Vonage = require("nexmo");
 const https = require("https");
 
+const PORT = '3200';
+
 const app = express();
 app.use(express.json());
 app.use(express.static("public"));
@@ -54,7 +56,7 @@ async function processFiles(files, appId) {
   return new Promise((resolve, reject) => {
     const options = {
       hostname: "api.nexmo.com",
-      path: `/v1/applications/${appId}/push_tokens/ios`,
+      path: `/v1/applications/${appId}/push_tokens/android`,
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
@@ -91,8 +93,8 @@ async function processFiles(files, appId) {
   });
 }
 
-const listener = app.listen(process.env.PORT, () => {
-  console.log("Your app is listening on port " + listener.address().port);
+const listener = app.listen(PORT, () => {
+  console.log("App available at: http://localhost:" + listener.address().port + "/");
 });
 
 function getJwt(appId, privateKeyBuffer) {

--- a/server.js
+++ b/server.js
@@ -56,7 +56,7 @@ async function processFiles(files, appId) {
   return new Promise((resolve, reject) => {
     const options = {
       hostname: "api.nexmo.com",
-      path: `/v1/applications/${appId}/push_tokens/android`,
+      path: `/v1/applications/${appId}/push_tokens/ios`,
       method: "PUT",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
1. Port value is set in stone, so user can easily refresh the page without wondering about the port number (actually URL) on subsequent launches 

2. Message after launching the app is improved
Old: `Your app is listening on port 3200`
New: `App available at: http://localhost:3200/`

Benefits of new message:
- Consistent with our `server.js` approach from tutorial samples
- Present exact app url to the user, not only port
- Terminal allows cmd+click to open app in the browser
