### PR TITLE
Add explicit vendor names 

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -16,17 +16,17 @@
   <br />
   <form>
     <label>
-      App ID
+      Vonage App ID
       <input name="appid" type="text" required />
     </label>
     <br />
     <label>
-      Private key
+      Vonage Private key
       <input name="privatekey" type="file" accept=".key" required />
     </label>
     <br />
     <label>
-      certificate (.p12)
+      Apple certificate (.p12)
       <input name="certificate" type="file" accept=".p12" required />
     </label>
     <br />


### PR DESCRIPTION
Add explicit names to easily determine the source of a given key/cert. This way user should have no doubt where certain key/cert should be acquired during integration.
