### PR TITLE
Display full URL in console

### DIFF
--- a/server.js
+++ b/server.js
@@ -92,7 +92,7 @@ async function processFiles(files, appId) {
 }
 
 const listener = app.listen(process.env.PORT, () => {
-  console.log("Your app is listening on port " + listener.address().port);
+  console.log("App available at: http://localhost:" + listener.address().port + "/");
 });
 
 function getJwt(appId, privateKeyBuffer) {


### PR DESCRIPTION
This allows cmd+click to open the URL in the browser.
Also, the message matches our webhook server message.
